### PR TITLE
Add the keep-git-dir flag

### DIFF
--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -21,7 +21,7 @@ func TestSync(t *testing.T) {
 
 	// Need to override for test
 	RootFlagValues.SpecFilePath = testSpecFilePath
-	err = sync()
+	err = sync(false)
 	require.NoError(t, err)
 
 	// defer t.Cleanup(func() {

--- a/internal/remotes/git.go
+++ b/internal/remotes/git.go
@@ -12,7 +12,7 @@ import (
 )
 
 // SyncGit is the root of the sync operations for "git" remote types.
-func SyncGit(remote vdmspec.Remote) error {
+func SyncGit(remote vdmspec.Remote, keepGitDir bool) error {
 	err := gitClone(remote)
 	if err != nil {
 		return fmt.Errorf("cloing remote: %w", err)
@@ -27,11 +27,13 @@ func SyncGit(remote vdmspec.Remote) error {
 		}
 	}
 
-	message.Debugf("removing .git dir for local path '%s'", remote.LocalPath)
-	dotGitPath := filepath.Join(remote.LocalPath, ".git")
-	err = os.RemoveAll(dotGitPath)
-	if err != nil {
-		return fmt.Errorf("removing directory %s: %w", dotGitPath, err)
+	if !keepGitDir {
+		message.Debugf("removing .git dir for local path '%s'", remote.LocalPath)
+		dotGitPath := filepath.Join(remote.LocalPath, ".git")
+		err = os.RemoveAll(dotGitPath)
+		if err != nil {
+			return fmt.Errorf("removing directory %s: %w", dotGitPath, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
I added the `--keep-git-dir` flag in order to preserve the `.git` directory when cloning.

Note that, if you clone once without the flag the with the flag, the .git file will not be re-added since the clone will be ignored. Maybe this information should be kept in the VDMMETA file? Or a --force option should be added to re-download?

Also, I'm thinking of adding the keep-git-dir as an option to have a more precise control over which repo should have or not their `.git` directory. I would gladly add it to this PR if you judge it a good addition.

EDIT: I have made the changes but not commited / pushed

